### PR TITLE
feat(players): replace mock list with live fxserver data

### DIFF
--- a/api/internal/api/api.go
+++ b/api/internal/api/api.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/runfivedev/runfive/internal/api/v1"
 	"github.com/runfivedev/runfive/internal/artifacts"
 	"github.com/runfivedev/runfive/internal/auth"
+	"github.com/runfivedev/runfive/internal/fxserver"
 	"github.com/runfivedev/runfive/internal/launcher"
 	"github.com/runfivedev/runfive/internal/serverfs"
 	"github.com/runfivedev/runfive/internal/spa"
@@ -37,6 +38,8 @@ type AppDeps struct {
 	ST *auth.SetupTokenStore
 	// BaseURL is the public base URL for constructing invite links.
 	BaseURL string
+	// FxRuntime queries live fxserver HTTP endpoints (players.json, etc).
+	FxRuntime *fxserver.RuntimeClient
 }
 
 // New creates the Fiber application with all middleware and routes.
@@ -66,5 +69,5 @@ func New(appConfig *fiber.Config, deps *AppDeps) *fiber.App {
 
 func setupRoutes(app *fiber.App, deps *AppDeps) {
 	v1Group := app.Group("/v1")
-	v1.RegisterRouter(v1Group, deps.DB, deps.SM, deps.Cfx, deps.FE, deps.Discord, deps.ST, deps.BaseURL, deps.ArtifactManager, deps.ServerRegistry, deps.Launcher)
+	v1.RegisterRouter(v1Group, deps.DB, deps.SM, deps.Cfx, deps.FE, deps.Discord, deps.ST, deps.BaseURL, deps.ArtifactManager, deps.ServerRegistry, deps.Launcher, deps.FxRuntime)
 }

--- a/api/internal/api/v1/routes.go
+++ b/api/internal/api/v1/routes.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/runfivedev/runfive/internal/artifacts"
 	"github.com/runfivedev/runfive/internal/auth"
+	"github.com/runfivedev/runfive/internal/fxserver"
 	"github.com/runfivedev/runfive/internal/launcher"
 	"github.com/runfivedev/runfive/internal/permissions"
 	"github.com/runfivedev/runfive/internal/serverfs"
 )
 
 // RegisterRouter mounts all v1 API routes on the provided router group.
-func RegisterRouter(r fiber.Router, db *gorm.DB, sm *auth.SessionManager, cfx *auth.CfxAuth, fe *auth.FieldEncryptor, discord *auth.DiscordAuth, st *auth.SetupTokenStore, baseURL string, artifactManager *artifacts.Manager, serverRegistry *serverfs.Registry, launcherManager *launcher.Manager) {
+func RegisterRouter(r fiber.Router, db *gorm.DB, sm *auth.SessionManager, cfx *auth.CfxAuth, fe *auth.FieldEncryptor, discord *auth.DiscordAuth, st *auth.SetupTokenStore, baseURL string, artifactManager *artifacts.Manager, serverRegistry *serverfs.Registry, launcherManager *launcher.Manager, fxRuntime *fxserver.RuntimeClient) {
 	authHandler := NewAuthHandler(db, sm, cfx, fe, discord, st)
 	authGroup := r.Group("/auth")
 
@@ -81,7 +82,7 @@ func RegisterRouter(r fiber.Router, db *gorm.DB, sm *auth.SessionManager, cfx *a
 	roleGroup.Delete("/:id", auth.RequireGlobalPerm(permissions.GlobalRoles, permissions.ActionDelete), roleHandler.Delete)
 
 	// Server management endpoints (permission-based)
-	serverHandler := NewServerHandler(serverRegistry, artifactManager, launcherManager)
+	serverHandler := NewServerHandler(serverRegistry, artifactManager, launcherManager, fxRuntime)
 	serverGroup := r.Group("/servers", auth.RequireAuth(sm, db), auth.LoadPermissions(db))
 	serverGroup.Get("", serverHandler.List)
 	serverGroup.Post("", auth.RequireGlobalPerm(permissions.GlobalServers, permissions.ActionCreate), serverHandler.Create)
@@ -102,6 +103,7 @@ func RegisterRouter(r fiber.Router, db *gorm.DB, sm *auth.SessionManager, cfx *a
 	serverGroup.Post("/:serverId/stop", auth.RequireServerPerm(permissions.ServerConsole, permissions.ActionExecute), serverHandler.Stop)
 	serverGroup.Get("/:serverId/status", auth.RequireServerPerm(permissions.ServerConsole, permissions.ActionRead), serverHandler.Status)
 	serverGroup.Get("/:serverId/logs", auth.RequireServerPerm(permissions.ServerConsole, permissions.ActionRead), serverHandler.Logs)
+	serverGroup.Get("/:serverId/players", auth.RequireServerPerm(permissions.ServerConsole, permissions.ActionRead), serverHandler.Players)
 	serverGroup.Get(
 		"/:serverId/logs/ws",
 		auth.RequireServerPerm(permissions.ServerConsole, permissions.ActionRead),

--- a/api/internal/api/v1/servers.go
+++ b/api/internal/api/v1/servers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 
 	"github.com/runfivedev/runfive/internal/auth"
+	"github.com/runfivedev/runfive/internal/fxserver"
 	"github.com/runfivedev/runfive/internal/launcher"
 	"github.com/runfivedev/runfive/internal/models"
 	"github.com/runfivedev/runfive/internal/permissions"
@@ -52,16 +53,25 @@ type serverLauncher interface {
 	IsRunning(string) bool
 }
 
+// serverRuntimeClient talks to a running fxserver's HTTP endpoint. The
+// interface keeps the handler test-friendly — production wiring passes a
+// *fxserver.RuntimeClient, tests can substitute a fake without spinning up
+// a real listener.
+type serverRuntimeClient interface {
+	FetchPlayers(ctx context.Context, port int) ([]fxserver.Player, error)
+}
+
 // ServerHandler serves filesystem-backed managed server endpoints.
 type ServerHandler struct {
 	registry  serverRegistry
 	artifacts serverArtifactManager
 	launcher  serverLauncher
+	fxRuntime serverRuntimeClient
 }
 
 // NewServerHandler creates a server handler with its dependencies.
-func NewServerHandler(registry serverRegistry, artifacts serverArtifactManager, serverLauncher serverLauncher) *ServerHandler {
-	return &ServerHandler{registry: registry, artifacts: artifacts, launcher: serverLauncher}
+func NewServerHandler(registry serverRegistry, artifacts serverArtifactManager, serverLauncher serverLauncher, fxRuntime serverRuntimeClient) *ServerHandler {
+	return &ServerHandler{registry: registry, artifacts: artifacts, launcher: serverLauncher, fxRuntime: fxRuntime}
 }
 
 // List returns filesystem-discovered servers, filtered by RBAC visibility.
@@ -262,6 +272,40 @@ func (h *ServerHandler) Logs(c fiber.Ctx) error {
 		return launcherHTTPError(err)
 	}
 	return c.JSON(models.ServerLogsResponse{Lines: lines})
+}
+
+// Players returns the live player list sourced from fxserver's players.json
+// loopback endpoint.
+//
+// GET /v1/servers/:serverId/players
+//
+// Returns an empty array (200) when the server is not running, when the
+// registered port is zero (no listener), or when the HTTP call to fxserver
+// fails or times out. The UI polls this every 5 s and flipping between 200
+// and 5xx during boot windows would produce error toasts for transient
+// states — a calm zero-player view is the better default. A genuine server
+// lookup failure still returns 404 so RBAC filtering stays distinguishable
+// from runtime unavailability.
+func (h *ServerHandler) Players(c fiber.Ctx) error {
+	serverID := c.Params("serverId")
+	server, ok := h.registry.Get(serverID)
+	if !ok {
+		return fiber.NewError(fiber.StatusNotFound, "server not found")
+	}
+
+	status, err := h.launcher.Status(serverID)
+	if err != nil || status.Status != models.ServerStatusRunning {
+		return c.JSON([]fxserver.Player{})
+	}
+	if server.Port <= 0 {
+		return c.JSON([]fxserver.Player{})
+	}
+
+	players, err := h.fxRuntime.FetchPlayers(c.Context(), server.Port)
+	if err != nil {
+		return c.JSON([]fxserver.Player{})
+	}
+	return c.JSON(players)
 }
 
 // StreamLogs upgrades to a websocket that streams console lines and accepts

--- a/api/internal/api/v1/servers_test.go
+++ b/api/internal/api/v1/servers_test.go
@@ -1,0 +1,303 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+
+	"github.com/runfivedev/runfive/internal/fxserver"
+	"github.com/runfivedev/runfive/internal/launcher"
+	"github.com/runfivedev/runfive/internal/models"
+	"github.com/runfivedev/runfive/internal/serverfs"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeRegistry struct {
+	servers map[string]models.ManagedServer
+}
+
+func (f *fakeRegistry) List() ([]models.ManagedServer, error) {
+	out := make([]models.ManagedServer, 0, len(f.servers))
+	for id := range f.servers {
+		out = append(out, f.servers[id])
+	}
+	return out, nil
+}
+
+func (f *fakeRegistry) Get(id string) (models.ManagedServer, bool) {
+	s, ok := f.servers[id]
+	return s, ok
+}
+
+func (f *fakeRegistry) Create(string, string, string, int, int) (models.ManagedServer, error) {
+	return models.ManagedServer{}, errors.New("not implemented")
+}
+
+func (f *fakeRegistry) Update(string, *serverfs.UpdatePatch) (models.ManagedServer, error) {
+	return models.ManagedServer{}, errors.New("not implemented")
+}
+
+func (f *fakeRegistry) Delete(string, bool) error { return errors.New("not implemented") }
+func (f *fakeRegistry) Reload() error             { return nil }
+
+type fakeArtifacts struct{}
+
+func (fakeArtifacts) Install(context.Context, string) (models.InstalledArtifact, error) {
+	return models.InstalledArtifact{}, errors.New("not implemented")
+}
+
+type fakeLauncher struct {
+	status    models.ServerProcessStatus
+	statusErr error
+}
+
+func (f *fakeLauncher) Start(string) (models.ServerProcessStatus, error) {
+	return models.ServerProcessStatus{}, errors.New("not implemented")
+}
+
+func (f *fakeLauncher) Stop(string) (models.ServerProcessStatus, error) {
+	return models.ServerProcessStatus{}, errors.New("not implemented")
+}
+
+func (f *fakeLauncher) Status(string) (models.ServerProcessStatus, error) {
+	return f.status, f.statusErr
+}
+
+func (f *fakeLauncher) Tail(string, int) ([]models.ServerLogLine, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeLauncher) Subscribe(string) (*launcher.Subscription, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeLauncher) SendCommand(string, string) error { return errors.New("not implemented") }
+func (f *fakeLauncher) IsRunning(string) bool            { return false }
+
+type fakeRuntimeClient struct {
+	players   []fxserver.Player
+	err       error
+	lastPort  int
+	callCount int
+}
+
+func (f *fakeRuntimeClient) FetchPlayers(_ context.Context, port int) ([]fxserver.Player, error) {
+	f.lastPort = port
+	f.callCount++
+	return f.players, f.err
+}
+
+// --- helpers -------------------------------------------------------------
+
+type playersDeps struct {
+	registry *fakeRegistry
+	launcher *fakeLauncher
+	runtime  *fakeRuntimeClient
+}
+
+func newPlayersApp(deps playersDeps) *fiber.App {
+	app := fiber.New()
+	handler := NewServerHandler(deps.registry, fakeArtifacts{}, deps.launcher, deps.runtime)
+	app.Get("/v1/servers/:serverId/players", handler.Players)
+	return app
+}
+
+func doPlayersRequest(t *testing.T, app *fiber.App, serverID string) (status int, body []byte) {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/servers/"+serverID+"/players", http.NoBody)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode, body
+}
+
+func decodePlayers(t *testing.T, body []byte) []fxserver.Player {
+	t.Helper()
+	var players []fxserver.Player
+	if err := json.Unmarshal(body, &players); err != nil {
+		t.Fatalf("decode body %q: %v", string(body), err)
+	}
+	return players
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestPlayers_UnknownServer(t *testing.T) {
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{}},
+		launcher: &fakeLauncher{},
+		runtime:  &fakeRuntimeClient{},
+	}
+	app := newPlayersApp(deps)
+
+	status, _ := doPlayersRequest(t, app, "ghost")
+	if status != http.StatusNotFound {
+		t.Fatalf("unknown server: want 404, got %d", status)
+	}
+	if deps.runtime.callCount != 0 {
+		t.Errorf("runtime client must not be called for unknown server")
+	}
+}
+
+func TestPlayers_ServerStopped(t *testing.T) {
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{
+			"alpha": {ID: "alpha", Port: 30120},
+		}},
+		launcher: &fakeLauncher{status: models.ServerProcessStatus{Status: models.ServerStatusStopped}},
+		runtime:  &fakeRuntimeClient{},
+	}
+	app := newPlayersApp(deps)
+
+	status, body := doPlayersRequest(t, app, "alpha")
+	if status != http.StatusOK {
+		t.Fatalf("stopped server: want 200, got %d", status)
+	}
+	if got := decodePlayers(t, body); len(got) != 0 {
+		t.Errorf("stopped server: want empty list, got %+v", got)
+	}
+	if deps.runtime.callCount != 0 {
+		t.Errorf("runtime client must not be called for stopped server")
+	}
+}
+
+func TestPlayers_LauncherStatusError(t *testing.T) {
+	// Registry unaware of launcher failure — e.g. a race between reload and
+	// the launcher's internal state. Endpoint stays calm and reports zero
+	// players rather than surfacing a transient internal error.
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{
+			"alpha": {ID: "alpha", Port: 30120},
+		}},
+		launcher: &fakeLauncher{statusErr: errors.New("transient")},
+		runtime:  &fakeRuntimeClient{},
+	}
+	app := newPlayersApp(deps)
+
+	status, body := doPlayersRequest(t, app, "alpha")
+	if status != http.StatusOK {
+		t.Fatalf("launcher error: want 200, got %d", status)
+	}
+	if got := decodePlayers(t, body); len(got) != 0 {
+		t.Errorf("launcher error: want empty list, got %+v", got)
+	}
+	if deps.runtime.callCount != 0 {
+		t.Errorf("runtime client must not be called on launcher error")
+	}
+}
+
+func TestPlayers_RunningButNoPort(t *testing.T) {
+	// Port == 0 means the registry entry is downgraded / unresolved. We
+	// cannot hit loopback without a port; return an empty list rather than
+	// fabricate a target.
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{
+			"alpha": {ID: "alpha", Port: 0},
+		}},
+		launcher: &fakeLauncher{status: models.ServerProcessStatus{Status: models.ServerStatusRunning}},
+		runtime:  &fakeRuntimeClient{},
+	}
+	app := newPlayersApp(deps)
+
+	status, body := doPlayersRequest(t, app, "alpha")
+	if status != http.StatusOK {
+		t.Fatalf("no port: want 200, got %d", status)
+	}
+	if got := decodePlayers(t, body); len(got) != 0 {
+		t.Errorf("no port: want empty list, got %+v", got)
+	}
+	if deps.runtime.callCount != 0 {
+		t.Errorf("runtime client must not be called when port is 0")
+	}
+}
+
+func TestPlayers_RunningRuntimeError(t *testing.T) {
+	// fxserver booted but HTTP listener not up yet / transient refused —
+	// must not flap the UI into an error state while polling at 5 s.
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{
+			"alpha": {ID: "alpha", Port: 30120},
+		}},
+		launcher: &fakeLauncher{status: models.ServerProcessStatus{Status: models.ServerStatusRunning}},
+		runtime:  &fakeRuntimeClient{err: errors.New("connection refused")},
+	}
+	app := newPlayersApp(deps)
+
+	status, body := doPlayersRequest(t, app, "alpha")
+	if status != http.StatusOK {
+		t.Fatalf("runtime error: want 200, got %d", status)
+	}
+	if got := decodePlayers(t, body); len(got) != 0 {
+		t.Errorf("runtime error: want empty list, got %+v", got)
+	}
+	if deps.runtime.callCount != 1 {
+		t.Errorf("runtime client should have been called once, got %d", deps.runtime.callCount)
+	}
+}
+
+func TestPlayers_RunningWithPlayers(t *testing.T) {
+	want := []fxserver.Player{
+		{ID: 1, Name: "Alice", Ping: 42, License: "abc", Discord: "111"},
+		{ID: 2, Name: "Bob", Ping: 88, License: "def"},
+	}
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{
+			"alpha": {ID: "alpha", Port: 30120},
+		}},
+		launcher: &fakeLauncher{status: models.ServerProcessStatus{Status: models.ServerStatusRunning}},
+		runtime:  &fakeRuntimeClient{players: want},
+	}
+	app := newPlayersApp(deps)
+
+	status, body := doPlayersRequest(t, app, "alpha")
+	if status != http.StatusOK {
+		t.Fatalf("want 200, got %d", status)
+	}
+	got := decodePlayers(t, body)
+	if len(got) != len(want) {
+		t.Fatalf("player count: want %d, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("player[%d]: want %+v, got %+v", i, want[i], got[i])
+		}
+	}
+	if deps.runtime.lastPort != 30120 {
+		t.Errorf("runtime called with port %d, want 30120", deps.runtime.lastPort)
+	}
+}
+
+func TestPlayers_RunningEmpty(t *testing.T) {
+	// fxserver up, zero clients connected. Endpoint must return an empty
+	// JSON array — not null — so the frontend's length read is safe.
+	deps := playersDeps{
+		registry: &fakeRegistry{servers: map[string]models.ManagedServer{
+			"alpha": {ID: "alpha", Port: 30120},
+		}},
+		launcher: &fakeLauncher{status: models.ServerProcessStatus{Status: models.ServerStatusRunning}},
+		runtime:  &fakeRuntimeClient{players: []fxserver.Player{}},
+	}
+	app := newPlayersApp(deps)
+
+	status, body := doPlayersRequest(t, app, "alpha")
+	if status != http.StatusOK {
+		t.Fatalf("want 200, got %d", status)
+	}
+	if string(body) != "[]" {
+		t.Errorf("empty list must serialize as []; got %q", string(body))
+	}
+}

--- a/api/internal/fxserver/client.go
+++ b/api/internal/fxserver/client.go
@@ -1,0 +1,110 @@
+package fxserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// defaultTimeout caps runtime queries short enough that a tick hitch trips
+// fast, but long enough to survive the occasional GC pause on the fxserver
+// side. Handlers still wrap this in a request-scoped context so Fiber can
+// cancel the in-flight HTTP call when the client goes away.
+const defaultTimeout = 2 * time.Second
+
+// RuntimeClient fetches runtime data from a locally-running fxserver HTTP
+// endpoint. The panel and every managed server share a host, so every query
+// targets loopback — never the advertised address, which may be a DNS name
+// that does not resolve the same way from inside the panel.
+//
+// Named to distinguish from scraper.go's Client, which talks to the cfx.re
+// artifact index at build/install time and has nothing to do with a running
+// server.
+type RuntimeClient struct {
+	http *http.Client
+}
+
+// NewRuntimeClient builds a RuntimeClient with the default 2s HTTP timeout.
+func NewRuntimeClient() *RuntimeClient {
+	return &RuntimeClient{http: &http.Client{Timeout: defaultTimeout}}
+}
+
+// rawPlayer mirrors the on-the-wire /players.json element. Kept unexported
+// because the prefixed-string identifier layout is a detail of the fxserver
+// protocol; callers get the parsed Player type instead.
+type rawPlayer struct {
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Ping        int      `json:"ping"`
+	Endpoint    string   `json:"endpoint"`
+	Identifiers []string `json:"identifiers"`
+}
+
+// Player is the typed, identifier-parsed player record returned to callers
+// and serialized straight out of the API handler. Fields that depend on
+// identifiers the server did not collect are empty strings rather than
+// errors — a player without a linked Discord account is a normal state.
+type Player struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Ping    int    `json:"ping"`
+	License string `json:"license,omitempty"`
+	Discord string `json:"discord,omitempty"`
+}
+
+// FetchPlayers GETs http://127.0.0.1:<port>/players.json and returns the
+// parsed list. On connection refused, timeout, non-200 response, or
+// malformed JSON the caller receives an error; the HTTP handler converts
+// those failures into an empty list so the dashboard can keep polling
+// without error toasts during boot windows.
+func (c *RuntimeClient) FetchPlayers(ctx context.Context, port int) ([]Player, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/players.json", port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fxserver returned status %d", resp.StatusCode)
+	}
+
+	var raw []rawPlayer
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode players.json: %w", err)
+	}
+
+	players := make([]Player, 0, len(raw))
+	for _, r := range raw {
+		players = append(players, Player{
+			ID:      r.ID,
+			Name:    r.Name,
+			Ping:    r.Ping,
+			License: findIdentifier(r.Identifiers, "license"),
+			Discord: findIdentifier(r.Identifiers, "discord"),
+		})
+	}
+	return players, nil
+}
+
+// findIdentifier returns the value of the first identifier with the given
+// prefix (without the prefix), or "" if none matches. fxserver only ever
+// assigns a single identifier per provider per player, so returning the
+// first hit matches the real-world shape.
+func findIdentifier(identifiers []string, prefix string) string {
+	needle := prefix + ":"
+	for _, id := range identifiers {
+		if strings.HasPrefix(id, needle) {
+			return strings.TrimPrefix(id, needle)
+		}
+	}
+	return ""
+}

--- a/api/internal/fxserver/client_test.go
+++ b/api/internal/fxserver/client_test.go
@@ -1,0 +1,141 @@
+package fxserver
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// newTestServer starts an httptest.Server on a loopback port and returns
+// only that port. FetchPlayers hardcodes 127.0.0.1 so we rely on httptest's
+// default binding there; the server itself is torn down via t.Cleanup.
+func newTestServer(t *testing.T, handler http.HandlerFunc) int {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	parsed, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return port
+}
+
+func TestFetchPlayers_Success(t *testing.T) {
+	port := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/players.json" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":1,"name":"Alice","ping":42,"endpoint":"1.2.3.4:5","identifiers":["license:abc","discord:111","steam:222"]},
+			{"id":2,"name":"Bob","ping":88,"endpoint":"6.7.8.9:10","identifiers":["license:def"]}
+		]`))
+	})
+
+	players, err := NewRuntimeClient().FetchPlayers(context.Background(), port)
+	if err != nil {
+		t.Fatalf("FetchPlayers: %v", err)
+	}
+	if len(players) != 2 {
+		t.Fatalf("want 2 players, got %d", len(players))
+	}
+
+	alice := players[0]
+	if alice.ID != 1 || alice.Name != "Alice" || alice.Ping != 42 {
+		t.Errorf("alice scalar fields wrong: %+v", alice)
+	}
+	if alice.License != "abc" {
+		t.Errorf("alice license: want abc, got %q", alice.License)
+	}
+	if alice.Discord != "111" {
+		t.Errorf("alice discord: want 111, got %q", alice.Discord)
+	}
+
+	bob := players[1]
+	if bob.License != "def" {
+		t.Errorf("bob license: want def, got %q", bob.License)
+	}
+	if bob.Discord != "" {
+		t.Errorf("bob discord: want empty, got %q", bob.Discord)
+	}
+}
+
+func TestFetchPlayers_EmptyList(t *testing.T) {
+	port := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	players, err := NewRuntimeClient().FetchPlayers(context.Background(), port)
+	if err != nil {
+		t.Fatalf("FetchPlayers: %v", err)
+	}
+	if len(players) != 0 {
+		t.Fatalf("want empty slice, got %d entries", len(players))
+	}
+}
+
+func TestFetchPlayers_MissingIdentifiers(t *testing.T) {
+	port := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		// No identifiers at all — license and discord should both end up "".
+		_, _ = w.Write([]byte(`[{"id":1,"name":"Ghost","ping":0,"identifiers":[]}]`))
+	})
+
+	players, err := NewRuntimeClient().FetchPlayers(context.Background(), port)
+	if err != nil {
+		t.Fatalf("FetchPlayers: %v", err)
+	}
+	if len(players) != 1 || players[0].License != "" || players[0].Discord != "" {
+		t.Errorf("missing identifiers should produce empty strings, got %+v", players)
+	}
+}
+
+func TestFetchPlayers_NonOKStatus(t *testing.T) {
+	port := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	_, err := NewRuntimeClient().FetchPlayers(context.Background(), port)
+	if err == nil {
+		t.Fatal("want error on 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention status code, got %q", err.Error())
+	}
+}
+
+func TestFetchPlayers_MalformedJSON(t *testing.T) {
+	port := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	})
+
+	_, err := NewRuntimeClient().FetchPlayers(context.Background(), port)
+	if err == nil {
+		t.Fatal("want decode error, got nil")
+	}
+}
+
+func TestFetchPlayers_ConnectionRefused(t *testing.T) {
+	// Bind then immediately close to get a guaranteed-free port.
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	_, err = NewRuntimeClient().FetchPlayers(context.Background(), port)
+	if err == nil {
+		t.Fatal("want connect error, got nil")
+	}
+}

--- a/api/main.go
+++ b/api/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/runfivedev/runfive/internal/config"
 	"github.com/runfivedev/runfive/internal/console"
 	"github.com/runfivedev/runfive/internal/database"
+	"github.com/runfivedev/runfive/internal/fxserver"
 	"github.com/runfivedev/runfive/internal/launcher"
 	"github.com/runfivedev/runfive/internal/models"
 	"github.com/runfivedev/runfive/internal/runtimepath"
@@ -143,6 +144,7 @@ func main() {
 		Discord:         discord,
 		ST:              setupTokenStore,
 		BaseURL:         cfg.BaseURL,
+		FxRuntime:       fxserver.NewRuntimeClient(),
 	})
 
 	if setupURL != "" {

--- a/website/src/lib/api/players.ts
+++ b/website/src/lib/api/players.ts
@@ -4,43 +4,37 @@ import type { UndefinedInitialDataOptions } from "@tanstack/svelte-query";
 export interface Player {
     id: number;
     name: string;
-    discord: string;
-    license: string;
-    connectedSince: string;
-    allTimeConnected: string;
     ping: number;
-    source: number;
+    license: string;
+    discord: string;
 }
 
-// Mock data — replace with actual API call when backend is ready
-const mockPlayers: Player[] = [
-    { id: 1, name: "Kr3mu", discord: "kr3mu", license: "license:abcd1234ef56", connectedSince: "2h 14m", allTimeConnected: "342h", ping: 32, source: 1 },
-    { id: 2, name: "Lananal", discord: "lananal", license: "license:7890abcd1234", connectedSince: "1h 52m", allTimeConnected: "281h", ping: 28, source: 2 },
-    { id: 3, name: "xXDarkRiderXx", discord: "darkrider99", license: "license:ef567890abcd", connectedSince: "45m", allTimeConnected: "89h", ping: 54, source: 3 },
-    { id: 4, name: "TurboNinja", discord: "turboninja", license: "license:1234ef5678ab", connectedSince: "3h 01m", allTimeConnected: "512h", ping: 41, source: 4 },
-    { id: 5, name: "CoolGuy_2k", discord: "coolguy2k", license: "license:5678ab1234ef", connectedSince: "22m", allTimeConnected: "15h", ping: 67, source: 5 },
-    { id: 6, name: "SilentSniper", discord: "silentsniper", license: "license:abcdef123456", connectedSince: "1h 10m", allTimeConnected: "198h", ping: 38, source: 6 },
-    { id: 7, name: "PixelDrifter", discord: "pixeldrift", license: "license:654321fedcba", connectedSince: "4h 33m", allTimeConnected: "723h", ping: 22, source: 7 },
-    { id: 8, name: "NeonBlade", discord: "neonblade", license: "license:aabb11cc22dd", connectedSince: "15m", allTimeConnected: "42h", ping: 88, source: 8 },
-    { id: 9, name: "ChefRamsay_RP", discord: "cheframsay", license: "license:dd22cc11bbaa", connectedSince: "2h 45m", allTimeConnected: "456h", ping: 35, source: 9 },
-    { id: 10, name: "MidnightFox", discord: "midnightfox", license: "license:112233aabbcc", connectedSince: "58m", allTimeConnected: "67h", ping: 44, source: 10 },
-];
-
-async function fetchPlayers(): Promise<Player[]> {
-    // TODO: replace with actual API call
-    // return (await fetch("/api/v1/players")).json();
-    return mockPlayers;
+async function fetchPlayers(serverId: string): Promise<Player[]> {
+    const res: Response = await fetch(`/v1/servers/${encodeURIComponent(serverId)}/players`);
+    if (!res.ok) {
+        const payload: { error?: string } = await res.json().catch(() => ({}));
+        throw new Error(payload.error ?? `GET /v1/servers/${serverId}/players failed: ${res.status}`);
+    }
+    const players = (await res.json()) as Player[];
+    return players.map((p) => ({
+        id: p.id,
+        name: p.name,
+        ping: p.ping,
+        license: p.license ?? "",
+        discord: p.discord ?? "",
+    }));
 }
 
-export const playersQueryOptions = (): UndefinedInitialDataOptions<
-    Player[],
-    Error,
-    Player[],
-    string[]
-> =>
+export const playersQueryOptions = (
+    serverId: string | null,
+): UndefinedInitialDataOptions<Player[], Error, Player[], (string | null)[]> =>
     queryOptions({
-        queryKey: ["players"],
-        queryFn: fetchPlayers,
+        queryKey: ["players", serverId],
+        queryFn: () => {
+            if (!serverId) return Promise.resolve([]);
+            return fetchPlayers(serverId);
+        },
+        enabled: serverId !== null,
         refetchInterval: 1000 * 5, // poll every 5s — volatile data
         refetchIntervalInBackground: false,
     });

--- a/website/src/lib/components/dashboard/player-list.svelte
+++ b/website/src/lib/components/dashboard/player-list.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { createQuery } from "@tanstack/svelte-query";
     import { playersQueryOptions, type Player } from "$lib/api/players";
+    import { serverState } from "$lib/server-state.svelte";
     import Search from "@lucide/svelte/icons/search";
     import ArrowUpDown from "@lucide/svelte/icons/arrow-up-down";
     import ArrowUp from "@lucide/svelte/icons/arrow-up";
@@ -12,9 +13,10 @@
     import RefreshCw from "@lucide/svelte/icons/refresh-cw";
     import LoaderCircle from "@lucide/svelte/icons/loader-circle";
 
-    const players = createQuery(() => playersQueryOptions());
+    const selectedServerId = $derived(serverState.selectedId);
+    const players = createQuery(() => playersQueryOptions(selectedServerId));
 
-    type SortKey = "name" | "connectedSince" | "allTimeConnected" | "ping";
+    type SortKey = "name" | "ping";
     type SortDir = "asc" | "desc";
 
     let searchQuery = $state("");
@@ -24,17 +26,8 @@
         null,
     );
 
-    function parseTime(t: string): number {
-        let total = 0;
-        const hMatch = t.match(/(\d+)h/);
-        const mMatch = t.match(/(\d+)m/);
-        if (hMatch) total += parseInt(hMatch[1]) * 60;
-        if (mMatch) total += parseInt(mMatch[1]);
-        return total;
-    }
-
     const filteredPlayers = $derived(() => {
-        const data = players.data ?? [];
+        const data: Player[] = players.data ?? [];
         let result = [...data];
 
         if (searchQuery) {
@@ -51,12 +44,6 @@
             let cmp = 0;
             if (sortKey === "name") cmp = a.name.localeCompare(b.name);
             else if (sortKey === "ping") cmp = a.ping - b.ping;
-            else if (sortKey === "connectedSince")
-                cmp = parseTime(a.connectedSince) - parseTime(b.connectedSince);
-            else if (sortKey === "allTimeConnected")
-                cmp =
-                    parseTime(a.allTimeConnected) -
-                    parseTime(b.allTimeConnected);
             return sortDir === "asc" ? cmp : -cmp;
         });
 
@@ -201,24 +188,6 @@
                                 {@render sortIcon("ping")}
                             </button>
                         </th>
-                        <th class="px-3 py-2">
-                            <button
-                                onclick={() => toggleSort("connectedSince")}
-                                class="flex items-center gap-1 text-[11px] font-semibold tracking-wider text-muted-foreground/60 uppercase transition-colors hover:text-foreground"
-                            >
-                                Session
-                                {@render sortIcon("connectedSince")}
-                            </button>
-                        </th>
-                        <th class="hidden px-3 py-2 lg:table-cell">
-                            <button
-                                onclick={() => toggleSort("allTimeConnected")}
-                                class="flex items-center gap-1 text-[11px] font-semibold tracking-wider text-muted-foreground/60 uppercase transition-colors hover:text-foreground"
-                            >
-                                Total
-                                {@render sortIcon("allTimeConnected")}
-                            </button>
-                        </th>
                         <th class="px-3 py-2 text-right">
                             <span
                                 class="text-[11px] font-semibold tracking-wider text-muted-foreground/60 uppercase"
@@ -238,7 +207,7 @@
                                 <span
                                     class="inline-flex h-6 min-w-6 items-center justify-center rounded bg-primary/8 px-1.5 font-mono text-[11px] font-bold text-primary/70"
                                 >
-                                    {player.source}
+                                    {player.id}
                                 </span>
                             </td>
                             <td class="py-1.5 pl-2 pr-3">
@@ -249,15 +218,25 @@
                             </td>
                             <td class="px-3 py-1.5">
                                 <span class="text-xs text-muted-foreground/70"
-                                    >{player.discord}</span
+                                    >{player.discord || "—"}</span
                                 >
                             </td>
                             <td class="hidden px-3 py-1.5 xl:table-cell">
-                                <code
-                                    class="rounded bg-muted/50 px-1.5 py-px font-mono text-[11px] text-muted-foreground/50"
-                                >
-                                    {player.license.slice(0, 22)}...
-                                </code>
+                                {#if player.license}
+                                    <code
+                                        class="rounded bg-muted/50 px-1.5 py-px font-mono text-[11px] text-muted-foreground/50"
+                                    >
+                                        {player.license.slice(0, 22)}{player
+                                            .license.length > 22
+                                            ? "…"
+                                            : ""}
+                                    </code>
+                                {:else}
+                                    <span
+                                        class="text-xs text-muted-foreground/30"
+                                        >—</span
+                                    >
+                                {/if}
                             </td>
                             <td class="px-3 py-1.5">
                                 <span
@@ -267,18 +246,6 @@
                                     >{player.ping}<span
                                         class="text-[10px] opacity-50">ms</span
                                     ></span
-                                >
-                            </td>
-                            <td class="px-3 py-1.5">
-                                <span
-                                    class="font-mono text-xs text-muted-foreground/60"
-                                    >{player.connectedSince}</span
-                                >
-                            </td>
-                            <td class="hidden px-3 py-1.5 lg:table-cell">
-                                <span
-                                    class="font-mono text-xs text-muted-foreground/50"
-                                    >{player.allTimeConnected}</span
                                 >
                             </td>
                             <td class="px-3 py-1.5">
@@ -335,7 +302,7 @@
                     {#if filteredPlayers().length === 0}
                         <tr>
                             <td
-                                colspan="8"
+                                colspan="6"
                                 class="py-8 text-center text-xs text-muted-foreground/30"
                             >
                                 No players found


### PR DESCRIPTION
## Summary
- `internal/fxserver.RuntimeClient.FetchPlayers` pulls the live player list from `http://127.0.0.1:<port>/players.json` with a 2s timeout, parses identifiers into typed `license`/`discord` fields, and always targets loopback.
- `GET /v1/servers/:serverId/players` (RBAC `server:console:read`) returns the live list when the launcher reports the server running and the registered port is non-zero. Server not found is 404; stopped / launcher-error / port-zero / unreachable fxserver all collapse to `200 []` so the dashboard's 5 s poll does not flap into error states during boot windows.
- `website/src/lib/api/players.ts` now hits the real endpoint with query key `["players", serverId]` and `enabled` tied to `serverState.selectedId`. The player widget drops the mock-only fields (`connectedSince`, `allTimeConnected`, `source`), reuses `player.id` for the slot column, and renders `—` when a player has no linked Discord or license.

Closes #8.

## Test plan
- [x] `go test ./internal/fxserver/...` — 6 cases: parse, empty, missing identifiers, non-200, malformed JSON, connection refused
- [x] `go test ./internal/api/v1/...` — 7 cases covering the handler decision matrix (unknown server, stopped, launcher error, port 0, runtime error, running-empty, running-with-players)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go vet ./...` — clean
- [x] `bun run build` — clean
- [x] Manual against a real fxserver: `Playertest` server started via panel, widget stayed empty during boot, returned `[{"id":1,"name":"manfred","ping":10}]` after a FiveM client connected, server switcher flipped the query key cleanly to `runfive-dev`
- [ ] Permissions smoke-check with a non-owner account that only has `server:console:read`
