### PR TITLE
ci: run all workflows on every PR

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -2,12 +2,8 @@ name: API CI
 
 on:
   push:
-    paths:
-      - "api/**"
-      - ".github/workflows/api.yml"
+    branches: [master]
   pull_request:
-    paths:
-      - "api/**"
 
 permissions:
   contents: read

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,12 +2,8 @@ name: Web Build
 
 on:
   push:
-    paths:
-      - "website/**"
-      - ".github/workflows/web.yml"
+    branches: [master]
   pull_request:
-    paths:
-      - "website/**"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Drop the `paths:` filters from `api.yml` and `web.yml` so every PR triggers every workflow. `push` stays scoped to `master` so feature branches do not double-spend CI minutes.

## Why
Preparing to enable master branch protection with required status checks. With path-filtered workflows, a PR that only touches one subtree would never fire the other workflow — its required checks would never report, and the merge button would stay blocked forever. Removing the filters makes every check fire on every PR.

The cost is a ~2-3 minute Go build/test on website-only PRs and vice versa. At current repo activity that is negligible.

## Test plan
- [ ] All four checks (`Lint & Format`, `Test`, `Build`, `build`) report on this PR
- [ ] All four pass